### PR TITLE
add matmul, update tests and READMEs

### DIFF
--- a/Synaptogen.jl/README.md
+++ b/Synaptogen.jl/README.md
@@ -19,7 +19,8 @@ These basic examples do the following:
 - Initialize a million memory cells (in their high resistance states)
 - Apply -2 V to each cell, putting them into their low resistance states
 - Apply a random voltage to each cell
-- Make a current readout of all the cells (at a default of 0.2 V)
+- Make a current readout of all the cells individually (at a default of 0.2 V)
+- Perform a "Vector Matrix Multiplication" by 1024×1024 crossbar readout
 
 #### CPU version
 
@@ -27,10 +28,17 @@ These basic examples do the following:
 using Synaptogen
 M = 2^20
 cells = [Cell() for m in 1:M]
+
 applyVoltage!.(cells, -2)
+
 voltages = randn(Float32, M)
 applyVoltage!.(cells, voltages)
+
 I = Iread.(cells)
+
+crossbar = reshape(cells, 1024, 1024) # Reshaping optional
+col_voltages = randn(Float32, 1024) * .2f0
+row_currents = crossbar * col_voltages
 ```
 
 #### GPU version
@@ -39,8 +47,14 @@ I = Iread.(cells)
 using Synaptogen, CUDA
 M = 2^20
 cells = CellArrayGPU(M)
+
 applyVoltage!(cells, -2)
+
 voltages = CUDA.randn(M)
 applyVoltage!(cells, voltages)
+
 I = Iread(cells)
+
+col_voltages = CUDA.randn(1024) * .2f0
+row_currents = cells * col_voltages
 ```

--- a/Synaptogen.jl/src/Synaptogen.jl
+++ b/Synaptogen.jl/src/Synaptogen.jl
@@ -1,6 +1,6 @@
 module Synaptogen
 
-export applyVoltage!, Iread, Uread, HRS, LRS, UR, US, I,
+export applyVoltage!, Iread, Uread, HRS, LRS, UR, US, I, ADC,
        CellArray, CellArrayCPU, CellArrayGPU, Cell,
        CellParams, CellParams_from_artifact, StaticCellParams, defaultParams, defaultStaticParams
 

--- a/Synaptogen.py/README.md
+++ b/Synaptogen.py/README.md
@@ -17,14 +17,22 @@ This basic example does the following:
 - Apply -2 V to each cell, putting them into their low resistance states
 - Apply a random voltage to each cell
 - Make a current readout of all the cells (at a default of 0.2 V)
+- Perform a "Vector Matrix Multiplication" by 1024×1024 crossbar readout
+
 
 ```python
 from synaptogen import *
 import numpy as np
-M = 2**20
+M = 2**20 # = 32×32
 cells = CellArrayCPU(M)
+
 applyVoltage(cells, -2)
+
 voltages = np.random.randn(M)
 applyVoltage(cells, voltages)
+
 I = Iread(cells)
+
+col_voltages = np.random.randn(2**5) * .2
+row_currents = cells @ col_voltages
 ```


### PR DESCRIPTION
Crossbar readout implemented, "overloading" the normal matrix multiply infix notation.

ADC function separated from Iread(), so we can apply it to the crossbar readout if desired.